### PR TITLE
グループのユーザー情報の非同期化

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,61 @@
+$(function() {
+  function addUser(user) {
+    let html = 
+      `<div class="ChatMember clearfix">
+        <p class="ChatMember__name">${user.name}</p>
+        <div class="ChatMember__add ChatMember__button" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+      </div>`
+      $("#UserSearchResult").append(html);
+  }
+  function addNoUser() {
+    let html =
+      `<div class="ChatMember clearfix">
+        <p class="ChatMember__name">ユーザーが見つかりません</p>
+      </div>`
+    $("#UserSearchResult").append(html);
+  }
+  function addMember(name, id) {
+    let html =
+      `<div class="ChatMember">
+        <p class="ChatMember__name">${name}</p>
+        <input name="group[user_ids][]" type="hidden" value="${id}" />
+        <div class="ChatMember__remove ChatMember__button">削除</div>
+      </div>`
+    $(".ChatMembers").append(html);
+  }
+
+  $('#UserSearch__field').on('keyup', function() {
+    let input = $('#UserSearch__field').val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $("#UserSearchResult").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          addUser(user);
+        });
+      } else if (users.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function() {
+      alert("ユーザー検索に失敗しました");
+    })
+  });
+
+  $('#UserSearchResult').on('click', '.ChatMember__add', function() {
+    const user_name = $(this).attr('data-user-name');
+    const user_id = $(this).attr('data-user-id');
+    $(this).parent().remove();
+    addMember(user_name, user_id);
+  });
+  $('.ChatMembers').on('click', '.ChatMember__remove', function() {
+    $(this).parent().remove();
+  })
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,12 @@
 class UsersController < ApplicationController
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where( ['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
   def edit
   end
   def update

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,8 +15,26 @@
       %label.SettingGroupForm__label チャットメンバーを追加
     .SettingGroupForm__rightField
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / = f.collection_check_boxes :user_ids, User.all, :id, :name
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .UserSearch
+        %input#UserSearch__field.SettingGroupForm__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+      #UserSearchResult
+  .SettingGroupForm__field
+    .SettingGroupForm__leftField
+      = f.label :name, value: "チャットメンバー", class: "SettingGroupForm__label"
+    .SettingGroupForm__rightField
+      .ChatMembers
+        .ChatMemder
+          %p.ChatMember__name= current_user.name
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .ChatMember
+              %p.ChatMember__name
+                = user.name
+              .ChatMember__remove.ChatMember__button{"data-user-id": user.id, "data-user-name": user.name} 削除
+              %input{name: "group[user_ids][]", type:"hidden", value: user.id}
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
#What
グループの作成、編集におけるユーザー情報の追加削除を非同期で行えるよう、ajaxとインクリメンタルサーチを実装。
#Why
ユーザー検索をいちいちリロードしていては不便なため。
また、インクリメンタルサーチによる利便性の向上。